### PR TITLE
Initialize news-poster Kotlin project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "2.1.20"
+    kotlin("jvm") version "1.9.24"
 }
 
-group = "org.example"
+group = "news.poster"
 version = "1.0-SNAPSHOT"
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
-rootProject.name = "News-m"
+rootProject.name = "news-poster"


### PR DESCRIPTION
## Summary
- configure Kotlin JVM project using Gradle Kotlin DSL
- target JDK 17 with Kotlin 1.9.24
- set project name to `news-poster`

## Testing
- `./gradlew tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_68910f7aebc483218f8c45c96b41b647