### PR TITLE
Add Kotlin serialization and dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm") version "1.9.24"
+    kotlin("plugin.serialization") version "1.9.24"
 }
 
 group = "news.poster"
@@ -10,6 +13,14 @@ repositories {
 }
 
 dependencies {
+    implementation("io.ktor:ktor-client-cio:2.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("com.prof18.rssparser:rssparser:6.0.8")
+    implementation("org.jetbrains.exposed:exposed-core:0.53.0")
+    implementation("org.jetbrains.exposed:exposed-jdbc:0.53.0")
+    implementation("org.xerial:sqlite-jdbc:3.50.3.0")
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+    implementation("io.github.cdimascio:dotenv-kotlin:6.4.2")
     testImplementation(kotlin("test"))
 }
 
@@ -18,4 +29,7 @@ tasks.test {
 }
 kotlin {
     jvmToolchain(17)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
 }


### PR DESCRIPTION
## Summary
- enable Kotlin serialization plugin and target JVM 17
- add Ktor client, serialization, RSS parser, Exposed, SQLite, logging, and dotenv dependencies

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6891118a5d80832197c16a54647797be