### PR TITLE
Add SQLite data layer

### DIFF
--- a/src/main/kotlin/news/data/DatabaseFactory.kt
+++ b/src/main/kotlin/news/data/DatabaseFactory.kt
@@ -1,0 +1,14 @@
+package news.data
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
+
+object DatabaseFactory {
+    fun init() {
+        Database.connect("jdbc:sqlite:news.db", driver = "org.sqlite.JDBC")
+        transaction {
+            SchemaUtils.create(NewsTable)
+        }
+    }
+}

--- a/src/main/kotlin/news/data/NewsItem.kt
+++ b/src/main/kotlin/news/data/NewsItem.kt
@@ -1,0 +1,10 @@
+package news.data
+
+data class NewsItem(
+    val id: Int? = null,
+    val title: String,
+    val link: String,
+    val publishedAt: Long,
+    val source: String,
+    val hash: String
+)

--- a/src/main/kotlin/news/data/NewsRepository.kt
+++ b/src/main/kotlin/news/data/NewsRepository.kt
@@ -1,0 +1,22 @@
+package news.data
+
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class NewsRepository {
+    fun isDuplicate(hash: String): Boolean = transaction {
+        !NewsTable.select(NewsTable.hash eq hash).empty()
+    }
+
+    fun save(item: NewsItem) = transaction {
+        NewsTable.insert {
+            it[title] = item.title
+            it[link] = item.link
+            it[publishedAt] = item.publishedAt
+            it[sourceName] = item.source
+            it[hash] = item.hash
+        }
+    }
+}

--- a/src/main/kotlin/news/data/NewsTable.kt
+++ b/src/main/kotlin/news/data/NewsTable.kt
@@ -1,0 +1,14 @@
+package news.data
+
+import org.jetbrains.exposed.sql.Table
+
+object NewsTable : Table("news") {
+    val id = integer("id").autoIncrement()
+    val title = text("title")
+    val link = text("link")
+    val publishedAt = long("published_at")
+    val sourceName = text("source")
+    val hash = text("hash").uniqueIndex()
+
+    override val primaryKey = PrimaryKey(id)
+}


### PR DESCRIPTION
## Summary
- add `NewsItem` data model
- configure Exposed SQLite connection and schema
- implement repository with duplicate checks and save method

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6891140f89e883218214da73632af76c