### PR TITLE
Add news fetcher implementations

### DIFF
--- a/src/main/kotlin/news/fetcher/CoindeskJsonFetcher.kt
+++ b/src/main/kotlin/news/fetcher/CoindeskJsonFetcher.kt
@@ -1,0 +1,68 @@
+package news.fetcher
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import news.data.NewsItem
+import java.security.MessageDigest
+import java.time.Instant
+
+class CoindeskJsonFetcher(
+    private val client: HttpClient = HttpClient(CIO)
+) : NewsFetcher {
+
+    override suspend fun fetch(): List<NewsItem> {
+        val json = client.get(URL).bodyAsText()
+        val response = Json.decodeFromString<CoinDeskResponse>(json)
+        val usd = response.bpi["USD"] ?: return emptyList()
+        val title = "Bitcoin price is ${usd.rate} USD"
+        val link = "https://www.coindesk.com/price/bitcoin"
+        val publishedAt = runCatching {
+            Instant.parse(response.time.updatedISO).toEpochMilli()
+        }.getOrElse { System.currentTimeMillis() }
+        val source = "CoinDesk"
+        return listOf(
+            NewsItem(
+                title = title,
+                link = link,
+                publishedAt = publishedAt,
+                source = source,
+                hash = generateHash(source, title, link)
+            )
+        )
+    }
+
+    @Serializable
+    private data class CoinDeskResponse(
+        val time: Time,
+        val bpi: Map<String, Currency>
+    )
+
+    @Serializable
+    private data class Time(
+        @SerialName("updatedISO") val updatedISO: String
+    )
+
+    @Serializable
+    private data class Currency(
+        val code: String,
+        val rate: String,
+        @SerialName("rate_float") val rateFloat: Double,
+        val description: String
+    )
+
+    private fun generateHash(vararg values: String): String {
+        val md = MessageDigest.getInstance("MD5")
+        val bytes = md.digest(values.joinToString("|").toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        private const val URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+    }
+}
+

--- a/src/main/kotlin/news/fetcher/NewsFetcher.kt
+++ b/src/main/kotlin/news/fetcher/NewsFetcher.kt
@@ -1,0 +1,8 @@
+package news.fetcher
+
+import news.data.NewsItem
+
+interface NewsFetcher {
+    suspend fun fetch(): List<NewsItem>
+}
+

--- a/src/main/kotlin/news/fetcher/RssFetcher.kt
+++ b/src/main/kotlin/news/fetcher/RssFetcher.kt
@@ -1,0 +1,43 @@
+package news.fetcher
+
+import com.prof18.rssparser.RssParser
+import news.data.NewsItem
+import java.security.MessageDigest
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class RssFetcher(
+    private val feedUrl: String,
+    private val source: String,
+) : NewsFetcher {
+
+    private val parser = RssParser()
+
+    override suspend fun fetch(): List<NewsItem> {
+        val channel = parser.parse(feedUrl)
+        return channel.items.mapNotNull { item ->
+            val title = item.title ?: return@mapNotNull null
+            val link = item.link ?: return@mapNotNull null
+            val publishedAt = item.pubDate?.let {
+                runCatching {
+                    ZonedDateTime.parse(it, DateTimeFormatter.RFC_1123_DATE_TIME)
+                        .toInstant().toEpochMilli()
+                }.getOrElse { System.currentTimeMillis() }
+            } ?: System.currentTimeMillis()
+            NewsItem(
+                title = title,
+                link = link,
+                publishedAt = publishedAt,
+                source = source,
+                hash = generateHash(source, title, link)
+            )
+        }
+    }
+
+    private fun generateHash(vararg values: String): String {
+        val md = MessageDigest.getInstance("MD5")
+        val bytes = md.digest(values.joinToString("|").toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `NewsFetcher` interface and example fetchers for RSS feeds and CoinDesk's BTC price API

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6891162a3b788321b1316aea1118c51f