### PR TITLE
Add scheduler to run news fetchers periodically

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:2.3.7")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation("com.prof18.rssparser:rssparser:6.0.8")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     implementation("org.jetbrains.exposed:exposed-core:0.53.0")
     implementation("org.jetbrains.exposed:exposed-jdbc:0.53.0")
     implementation("org.xerial:sqlite-jdbc:3.50.3.0")

--- a/src/main/kotlin/news/Scheduler.kt
+++ b/src/main/kotlin/news/Scheduler.kt
@@ -1,0 +1,37 @@
+package news
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.SendChannel
+import news.data.NewsItem
+import news.data.NewsRepository
+import news.fetcher.NewsFetcher
+
+class Scheduler(
+    private val fetchers: List<NewsFetcher>,
+    private val repository: NewsRepository,
+    private val postingQueue: SendChannel<NewsItem>,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+) {
+    fun start() = scope.launch {
+        while (isActive) {
+            runFetchers()
+            delay(INTERVAL_MILLIS)
+        }
+    }
+
+    private suspend fun runFetchers() = coroutineScope {
+        fetchers.map { fetcher ->
+            async { fetcher.fetch() }
+        }.awaitAll().flatten().forEach { item ->
+            if (!repository.isDuplicate(item.hash)) {
+                repository.save(item)
+                postingQueue.send(item)
+            }
+        }
+    }
+
+    companion object {
+        private const val INTERVAL_MILLIS = 15 * 60 * 1000L
+    }
+}
+


### PR DESCRIPTION
## Summary
- add coroutine Scheduler that launches all fetchers every 15 minutes and enqueues new items for posting
- add kotlinx-coroutines dependency

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689117c84da08321bcf687674ebc62f9