### PR TITLE
Add Telegram posting and app entry point

### DIFF
--- a/src/main/kotlin/news/Main.kt
+++ b/src/main/kotlin/news/Main.kt
@@ -1,0 +1,41 @@
+package news
+
+import io.github.cdimascio.dotenv.dotenv
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import news.data.DatabaseFactory
+import news.data.NewsItem
+import news.data.NewsRepository
+import news.fetcher.CoindeskJsonFetcher
+import news.fetcher.NewsFetcher
+import news.fetcher.RssFetcher
+
+fun main() = runBlocking {
+    val env = dotenv()
+    DatabaseFactory.init()
+
+    val token = env["TELEGRAM_BOT_TOKEN"] ?: error("TELEGRAM_BOT_TOKEN not set")
+    val channelId = env["CHANNEL_ID"] ?: error("CHANNEL_ID not set")
+    val testMode = env["TEST_MODE"]?.lowercase() == "true"
+
+    val postingChannel = Channel<NewsItem>(Channel.UNLIMITED)
+    val repository = NewsRepository()
+    val fetchers: List<NewsFetcher> = listOf(
+        CoindeskJsonFetcher(),
+        RssFetcher("https://news.ycombinator.com/rss", "HackerNews")
+    )
+
+    val scheduler = Scheduler(fetchers, repository, postingChannel)
+    val poster = TelegramPoster(token, channelId)
+
+    val posterJob = poster.start(postingChannel)
+    val schedulerJob = scheduler.start()
+
+    if (testMode) {
+        poster.post("Hello, World!")
+    }
+
+    joinAll(posterJob, schedulerJob)
+}
+

--- a/src/main/kotlin/news/TelegramPoster.kt
+++ b/src/main/kotlin/news/TelegramPoster.kt
@@ -1,0 +1,36 @@
+package news
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
+import news.data.NewsItem
+
+class TelegramPoster(
+    private val token: String,
+    private val channelId: String,
+    private val client: HttpClient = HttpClient(CIO),
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+) {
+    fun start(source: ReceiveChannel<NewsItem>) = scope.launch {
+        for (item in source) {
+            post("${item.title}\n${item.link}")
+        }
+    }
+
+    suspend fun post(message: String) {
+        client.post("$BASE_URL$token/sendMessage") {
+            parameter("chat_id", channelId)
+            parameter("text", message)
+        }
+    }
+
+    companion object {
+        private const val BASE_URL = "https://api.telegram.org/bot"
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement TelegramPoster using Telegram Bot API
- wire data fetchers, scheduler, and poster in a new Main entry point
- send a test message on startup when TEST_MODE=true

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68911983eaf48321ae8fc814ab91bec3