### PR TITLE
Add Docker setup and CI workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TELEGRAM_BOT_TOKEN=your_bot_token
+CHANNEL_ID=your_channel_id
+TEST_MODE=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Run tests
+        run: ./gradlew test
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/OWNER/REPO:latest
+          # TODO: update image name and registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM eclipse-temurin:17-jdk AS jre-build
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules java.se \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /opt/jre
+
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=jre-build /opt/jre /opt/jre
+ENV PATH="/opt/jre/bin:${PATH}"
+COPY build/libs/*-all.jar app.jar
+CMD ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# News-m
+
+A Kotlin application that fetches news and posts updates to Telegram.
+
+## Local development
+
+1. Copy `.env.example` to `.env` and supply the required values.
+2. Run tests and build:
+   ```bash
+   ./gradlew test
+   ```
+3. Start the application:
+   ```bash
+   ./gradlew run
+   ```
+
+## Docker
+
+1. Build the fat jar and image:
+   ```bash
+   ./gradlew build
+   docker build -t news-m .
+   ```
+2. Run the container with your environment variables:
+   ```bash
+   docker run --env-file .env news-m
+   ```
+
+The image contains a minimal JRE produced with `jlink` and runs the packaged jar with `java -jar app.jar`.


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile using jlink-generated JRE 17
- introduce GitHub Actions workflow running tests and building Docker image
- document local usage, Docker commands, and environment variables

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68911aeeeec883219cbcdd1a409fb6a1